### PR TITLE
feat: Added info on consent revocation to Submission.Report 

### DIFF
--- a/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
@@ -161,18 +161,21 @@ with Logging
             metadata.researchConsents.exists(BroadConsent.permitsResearchUse)
         )
 
+      // Check for revocation of consent by comparing each Consent.Category status between the previous and current submission:
+      // Change of status from true -> false is interpreted as revocation
       val consentRevocation =
-        previousSubmissionReport.flatMap(_.consentStatus)
-          .map(
-            _.map {
-              case (category,previousStatus) => 
-                val hasBeenRevoked = (previousStatus,consentStatus(category)) match { 
-                  case (true,false) => true
-                  case _ => false
-                }
-                category -> hasBeenRevoked
+        for {
+          previousConsentStatus <- previousSubmissionReport.flatMap(_.consentStatus)
+        } yield Consent.Category.values.map {
+          category => 
+            val revoked = (previousConsentStatus.getOrElse(category,false), consentStatus(category)) match {
+              case (true,false) => true
+              case _ => false
             }
-          )
+            category -> revoked
+        }
+        .toMap
+
 
       repo.save(
         Submission.Report(

--- a/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
@@ -68,66 +68,32 @@ with Logging
         log.info(s"Processing MVH submission for Patient record ${record.id}")
 
         for {
+
           tanAlreadyUsed <- repo.alreadyUsed(metadata.transferTAN)
 
-          // Check acceptability of submission type for the given Patient
-          submissionTypeOk <- metadata.`type` match {
+          priorSubmissions <- repo.submissionReportHistory(record.patient.id)
 
-            // An initial submission must be the first at all or follow only previous "test" submissions
+          // Check acceptability of submission type for the given Patient
+          submissionTypeOk = metadata.`type` match {
+
+            // An Initial submission must be the first at all or follow only previous "test" submissions
             case Initial =>
-              repo.submissionReportHistory(record.patient.id).map {
+              priorSubmissions match {
                 case None => true
                 case Some(s) => s.history.forall(_.`type` == Test)
               }
 
-            // addition, correction, followup can only be appended to an existing submission history with an initial submission
+            // Addition, Correction, FollowUp can only be appended to an existing submission history with an initial submission
             case Addition | Correction | FollowUp =>
-              repo.submissionReportHistory(record.patient.id).map(_.exists(_.history.exists(_.`type` == Initial)))
+              priorSubmissions.exists(_.history.exists(_.`type` == Initial))
 
             // Test submission ok any time
-            case Test => env.pure(true)
+            case Test => true
           }
 
           result <- (!tanAlreadyUsed,submissionTypeOk) match {
             case (true,true) =>
-
-              val submittedAt = LocalDateTime.now
-  
-              repo.save(
-                Submission.Report(
-                  metadata.transferTAN,
-                  submittedAt,
-                  record.patient.id,
-                  Unsubmitted,
-                  Site.local,
-                  useCase,
-                  metadata.`type`,
-                  record.mvhSequencingReports.map(_.`type`.code.enumValue).maxOption,
-                  diagnosticExtent(record),
-                  sequenceTypes(record),
-                  record.patient.healthInsurance.`type`.code,
-                  Some(
-                    Map(
-                      Consent.Category.ModelProject ->
-                        metadata.modelProjectConsent.provisions.exists(p => p.purpose == Sequencing && p.`type` == Consent.Provision.Type.Permit),
-                      Consent.Category.Research ->
-                        metadata.researchConsents.exists(BroadConsent.permitsResearchUse)
-                    )
-                  ),
-                  metadata.reasonResearchConsentMissing
-                ),
-                Submission(
-                  record,
-                  metadata,
-                  submittedAt
-                )
-              )
-              .map(
-                _.bimap(
-                  GenericError(_),
-                  _ => Saved
-                )
-              )
+              processSubmission(record,metadata,priorSubmissions.map(_.latestBy(_.createdAt)))
 
             case (false,_) =>
               val msg = s"Invalid submission: TAN ${metadata.transferTAN} has already been used"
@@ -138,30 +104,29 @@ with Logging
               val msg = s"Invalid submission: Type ${metadata.`type`} is inconsistent with previous submission history"
               log.warn(s"$msg, refusing submission")
               env.pure(InvalidSubmissionType(msg).asLeft)
-          }
+
+            }
 
         } yield result
+
 
       case ConfirmSubmitted(id) =>
         for {
           optReport <- repo ? id
 
-          result <- 
-            optReport match {
-              case Some(report) =>
-                repo.update(report.copy(status = Submitted))
-                  .map(
-                    _.bimap(
-                      GenericError(_),
-                      _ => Updated
-                    )
+          result <- optReport match {
+            case Some(report) =>
+              repo.update(report.copy(status = Submitted))
+                .map(
+                  _.bimap(
+                    GenericError(_),
+                    _ => Updated
                   )
-
-              case None =>
-                env.pure(
-                  GenericError(s"Invalid TAN $id").asLeft
                 )
-            }
+
+            case None =>
+              env.pure(GenericError(s"Invalid TAN $id").asLeft)
+          }
 
         } yield result
 
@@ -175,6 +140,70 @@ with Logging
               _ => Deleted
             )
           )
+    }
+
+
+    private def processSubmission(
+      record: T,
+      metadata: Submission.Metadata,
+      previousSubmissionReport: Option[Submission.Report]
+    )(
+      implicit env: Monad[F]
+    ): F[Either[Error,Saved.type]] = {
+
+      val submittedAt = LocalDateTime.now
+
+      val consentStatus =
+        Map(
+          Consent.Category.ModelProject ->
+            metadata.modelProjectConsent.provisions.exists(p => p.purpose == Sequencing && p.`type` == Consent.Provision.Type.Permit),
+          Consent.Category.Research ->
+            metadata.researchConsents.exists(BroadConsent.permitsResearchUse)
+        )
+
+      val consentRevocation =
+        previousSubmissionReport.flatMap(_.consentStatus)
+          .map(
+            _.map {
+              case (category,previousStatus) => 
+                val hasBeenRevoked = (previousStatus,consentStatus(category)) match { 
+                  case (true,false) => true
+                  case _ => false
+                }
+                category -> hasBeenRevoked
+            }
+          )
+
+      repo.save(
+        Submission.Report(
+          metadata.transferTAN,
+          submittedAt,
+          record.patient.id,
+          Unsubmitted,
+          Site.local,
+          useCase,
+          metadata.`type`,
+          record.mvhSequencingReports.map(_.`type`.code.enumValue).maxOption,
+          diagnosticExtent(record),
+          sequenceTypes(record),
+          record.patient.healthInsurance.`type`.code,
+          Some(consentStatus),
+          consentRevocation,
+          metadata.reasonResearchConsentMissing
+        ),
+        Submission(
+          record,
+          metadata,
+          submittedAt
+        )
+      )
+      .map(
+        _.bimap(
+          GenericError(_),
+          _ => Saved
+        )
+      )
+
     }
 
 

--- a/src/main/scala/de/dnpm/dip/service/mvh/Submission.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/Submission.scala
@@ -69,7 +69,13 @@ object Submission
       Json.formatEnum(this)
   }
 
-
+  /**
+   * This DTO corresponds to a "Prüfbericht" for the Model Project.
+   * The structure is slightly different from the schema defined for the BfArM API:
+   * the conversion/mapping onto the later takes place in the central data node.
+   * Also, this DTO contains additional fields not representeded in the BfArM "Prüfbericht itself,
+   * but which are required for compilation of appendices 1/2 of the quarterly report.
+   */
   final case class Report
   (
     id: Id[TransferTAN],
@@ -80,10 +86,11 @@ object Submission
     useCase: UseCase.Value,
     `type`: Type.Value,
     sequencingType: Option[NGSReport.Type.Value],
-    diagnosticExtent: Option[DiagnosticExtent.Value],
-    sequenceTypes: Option[Set[SequenceType.Value]],
+    diagnosticExtent: Option[DiagnosticExtent.Value], // For quarter report (appendix 1)
+    sequenceTypes: Option[Set[SequenceType.Value]], // For quarter report (appendix 2)
     healthInsuranceType: HealthInsurance.Type.Value,
-    consentStatus: Option[Map[Consent.Category.Value,Boolean]],
+    consentStatus: Option[Map[Consent.Category.Value,Boolean]],      // For quarter report (appendix 2): Is the respective Consent given in the submission?
+    consentRevocation: Option[Map[Consent.Category.Value,Boolean]] , // For quarter report (appendix 2): Has the respective Consent been revoked (compared to previous submission)?
     reasonResearchConsentMissing: Option[BroadConsent.ReasonMissing.Value]
   )
 


### PR DESCRIPTION
Added info on consent revocation to Submission.Report for quarter report

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quarterly submission reports now include consent revocation flags in the report payload for compliance tracking.

* **Refactor**
  * Streamlined submission validation and persistence: single retrieval of prior submissions, simplified handling of submission types (Initial, Addition/Correction/FollowUp, Test), unified persistence orchestration, and clearer error signaling for invalid TANs and submission types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->