### PR TITLE
fix: Added a dedicated access method for Submission by TAN

### DIFF
--- a/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
@@ -134,7 +134,7 @@ with Logging
 
       case ConfirmSubmitted(id) =>
         for {
-          optReport <- repo ? id
+          optReport <- repo submissionReport id
 
           result <- optReport match {
             case Some(report) =>
@@ -238,16 +238,21 @@ with Logging
     repo ? filter
 
 
-  override def ?(id: Id[TransferTAN])(
+  override def submissionReport(id: Id[TransferTAN])(
     implicit env: Env
   ): F[Option[Submission.Report]] =
-    repo ? id
+    repo submissionReport id
 
 
   override def ?(filter: Submission.Filter)(
     implicit env: Env
   ): F[Seq[Submission[T]]] =
     repo ? filter
+
+  override def submission(id: Id[TransferTAN])(
+    implicit env: Env
+  ): F[Option[Submission[T]]] =
+    repo submission id
 
 
   // Create BaseReport for the criteria and return it together with the submissions it's based on,
@@ -267,9 +272,11 @@ with Logging
 
     for {
       submissions <- repo ? Submission.Filter(
-        period.copy(
-          start = period.start.atTime(LocalTime.MIN),
-          end   = period.end.atTime(LocalTime.MIDNIGHT),
+        period = Some(
+          period.copy(
+            start = period.start.atTime(LocalTime.MIN),
+            end   = period.end.atTime(LocalTime.MIDNIGHT),
+          )
         )
       )
 

--- a/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
@@ -110,8 +110,7 @@ with Logging
   ): SubmissionHeader => Boolean =
     submission =>
       filter.period.map(_ contains submission.submittedAt).getOrElse(true) &&
-      filter.`type`.map(_ contains submission.metadata.`type`).getOrElse(true) &&
-      filter.transferTAN.map(_ contains submission.metadata.transferTAN).getOrElse(true)
+      filter.`type`.map(_ contains submission.metadata.`type`).getOrElse(true)
 
 
   private val tolerantSubmissionReads = Submission.tolerantReads.submission[T]
@@ -136,6 +135,13 @@ with Logging
     dataDir.listFiles(
       (_,name) => name startsWith s"${SUBMISSION_PREFIX}_Patient_${id.value}"
     ) 
+
+  private def submissionFile(tan: Id[TransferTAN]): Option[File] =
+    dataDir.listFiles(
+      (_,name) => (name startsWith s"${SUBMISSION_PREFIX}") && (name contains tan.value)
+    )
+    .toList
+    .headOption
 
   private def toPrettyJson[A: Writes](a: A): String =
     Json.toJson(a) pipe Json.prettyPrint
@@ -251,7 +257,7 @@ with Logging
     .pure
 
 
-  override def ?(
+  override def submissionReport(
     id: Id[TransferTAN]
   )(
     implicit env: Env
@@ -304,6 +310,17 @@ with Logging
       .toSeq
       .pure
   }
+
+
+  override def submission(
+    id: Id[TransferTAN]
+  )(
+    implicit env: Env
+  ): F[Option[Submission[T]]] =
+    submissionFile(id)
+      .map(new FileInputStream(_))
+      .map(readAsJson(tolerantSubmissionReads))
+      .pure
 
 
   override def submissionHistory(id: Id[Patient])(

--- a/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
@@ -138,7 +138,7 @@ with Logging
 
   private def submissionFile(tan: Id[TransferTAN]): Option[File] =
     dataDir.listFiles(
-      (_,name) => (name startsWith s"${SUBMISSION_PREFIX}") && (name contains tan.value)
+      (_,name) => (name startsWith s"${SUBMISSION_PREFIX}") && (name endsWith s"TAN_${tan.value}.json")
     )
     .toList
     .headOption

--- a/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
@@ -138,7 +138,7 @@ with Logging
 
   private def submissionFile(tan: Id[TransferTAN]): Option[File] =
     dataDir.listFiles(
-      (_,name) => (name startsWith s"${SUBMISSION_PREFIX}") && (name endsWith s"TAN_${tan.value}.json")
+      (_,name) => (name startsWith SUBMISSION_PREFIX) && (name endsWith s"TAN_${tan.value}.json")
     )
     .toList
     .headOption

--- a/src/main/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
@@ -61,13 +61,25 @@ class InMemRepository[F[_],T <: PatientRecord] extends Repository[F,Monad[F],T]
   }
 
 
-  override def ?(
+  override def submissionReport(
     id: Id[TransferTAN]
   )(
     implicit env: Env
   ): F[Option[Submission.Report]] =
     reports.collectFirst {
       case (_,rs) if rs contains id => rs
+    }
+    .flatMap(_ get id)
+    .pure
+
+
+  override def submission(
+    id: Id[TransferTAN]
+  )(
+    implicit env: Env
+  ): F[Option[Submission[T]]] =
+    submissions.collectFirst {
+      case (_,subs) if subs contains id => subs
     }
     .flatMap(_ get id)
     .pure

--- a/src/main/scala/de/dnpm/dip/service/mvh/MVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/MVHService.scala
@@ -35,7 +35,7 @@ trait MVHService[F[_],Env,T <: PatientRecord]
   ): F[Seq[Submission.Report]]
 
 
-  def ?(
+  def submissionReport(
     id: Id[TransferTAN]
   )(
     implicit env: Env
@@ -46,6 +46,13 @@ trait MVHService[F[_],Env,T <: PatientRecord]
     implicit env: Env
   ): F[Seq[Submission[T]]]
   
+  
+  def submission(
+    id: Id[TransferTAN]
+  )(
+    implicit env: Env
+  ): F[Option[Submission[T]]]
+
   
   def statusInfo(
     implicit env: Env

--- a/src/main/scala/de/dnpm/dip/service/mvh/Repository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/Repository.scala
@@ -22,8 +22,7 @@ trait Repository[F[_],Env,T <: PatientRecord]
   protected implicit def submissionPredicate(filter: Submission.Filter): Submission[T] => Boolean =
     submission =>
       filter.period.map(_ contains submission.submittedAt).getOrElse(true) &&
-      filter.`type`.map(_ contains submission.metadata.`type`).getOrElse(true) &&
-      filter.transferTAN.map(_ contains submission.metadata.transferTAN).getOrElse(true)
+      filter.`type`.map(_ contains submission.metadata.`type`).getOrElse(true) 
 
   
   def alreadyUsed(id: Id[TransferTAN])(
@@ -49,7 +48,7 @@ trait Repository[F[_],Env,T <: PatientRecord]
     implicit env: Env
   ): F[Seq[Submission.Report]]
 
-  def ?(
+  def submissionReport(
     id: Id[TransferTAN]
   )(
     implicit env: Env
@@ -59,6 +58,12 @@ trait Repository[F[_],Env,T <: PatientRecord]
   def ?(filter: Submission.Filter)(
     implicit env: Env
   ): F[Seq[Submission[T]]]
+
+  def submission(
+    id: Id[TransferTAN]
+  )(
+    implicit env: Env
+  ): F[Option[Submission[T]]]
 
 
   def submissionHistory(id: Id[Patient])(

--- a/src/main/scala/de/dnpm/dip/service/mvh/Submission.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/Submission.scala
@@ -149,23 +149,10 @@ object Submission
 
   final case class Filter
   (
-    transferTAN: Option[Set[Id[TransferTAN]]] = None,
     `type`: Option[Set[Type.Value]] = None,
     period: Option[Period[LocalDateTime]] = None
   )
 
-  object Filter
-  {
-    def apply(period: Period[LocalDateTime]): Filter =
-      Filter(
-        period = Some(period)
-      )
-
-    def apply(transferTAN: Set[Id[TransferTAN]]): Filter =
-      Filter(
-        transferTAN = Some(transferTAN)
-      )
-  }
 
   import play.api.libs.json.JsPath
   import play.api.libs.functional.syntax._

--- a/src/test/scala/de/dnpm/dip/service/OrchestratorTests.scala
+++ b/src/test/scala/de/dnpm/dip/service/OrchestratorTests.scala
@@ -99,7 +99,7 @@ class OrchestratorTests extends AsyncFlatSpec
 
       _ = outcome.value mustBe Saved
 
-      submissionReport <- mvhService ? initialUpload.metadata.get.transferTAN
+      submissionReport <- mvhService submissionReport initialUpload.metadata.get.transferTAN
 
       _ = submissionReport.value.patient mustBe record.id
 
@@ -121,7 +121,7 @@ class OrchestratorTests extends AsyncFlatSpec
 
       _ = outcome.value mustBe Saved
 
-      submissionReport <- mvhService ? subsequentUpload.metadata.get.transferTAN
+      submissionReport <- mvhService submissionReport subsequentUpload.metadata.get.transferTAN
 
       _ = submissionReport.value.patient mustBe record.id
 
@@ -142,7 +142,7 @@ class OrchestratorTests extends AsyncFlatSpec
     
       _ = outcome.value mustBe a [Deleted]
 
-      submissionReport <- mvhService ? initialUpload.metadata.get.transferTAN
+      submissionReport <- mvhService submissionReport initialUpload.metadata.get.transferTAN
 
       _ = submissionReport must not be defined
     


### PR DESCRIPTION
fix: Removed TAN from Submission.Filter and instead added a dedicated method to get a Submission by TAN

refactor: Renamed method to get a Submission.Report by TAN

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Standardized internal API naming conventions to enhance code readability and maintainability in submission operations.
  * Streamlined submission filtering logic by removing unnecessary parameters and constraints.
  * Improved data access architecture by adding explicit methods for distinct submission retrieval scenarios.
  * Enhanced separation of concerns between submission reports and full submission data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->