### PR TITLE
feat: add validation warning for future invalid values

### DIFF
--- a/src/main/scala/de/dnpm/dip/service/validation/Validators.scala
+++ b/src/main/scala/de/dnpm/dip/service/validation/Validators.scala
@@ -62,6 +62,7 @@ import BroadConsent.ReasonMissing.{
 }
 import Issue.{
   Error,
+  Warning,
   Fatal,
   Path,
 }
@@ -461,7 +462,11 @@ trait Validators
             Error(s"Unzulässiger Wert, ab 01.06.2026 nur noch folgende gültig: {${admissibleConsentMissingReasons.mkString(", ")}}")
               at "Grund für fehlenden Broad Consent"
           )
-        else None.validNel
+        else
+          valueIn (metadata.reasonResearchConsentMissing) must be (in (admissibleConsentMissingReasons)) otherwise (
+            Warning(s"Der angegebene Wert ist ab dem 01.06.2026 ungültig und es können nur noch folgende Werte angegeben werden: {${admissibleConsentMissingReasons.mkString(", ")}}")
+              at "Grund für fehlenden Broad Consent"
+            )
       )
       .errorsOr(metadata) on "Metadaten"
 


### PR DESCRIPTION
This will add a warning if a reason for missing research consent is being used, that will be invalid after May 31, 2026.

The old behaviour was to add a validation error after May 31, 2026. Users should be warned earlier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added warning-level validation messages for clearer severity distinction in feedback.

* **Improvements**
  * Enhanced Broad Consent metadata validation to provide consistent handling, now issuing warnings for invalid values across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->