### PR TITLE
fix: Made check whether an initial submission exists more robust

### DIFF
--- a/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
@@ -75,19 +75,25 @@ with Logging
    * check whether and 'initial' submissions exists after this EpisodeOfCare's start date 
    */
   private def initialSubmissionExistsForEpisode(
-    reports: NonEmptyList[Submission.Report],
+    submissionReports: NonEmptyList[Submission.Report],
     episode: Option[EpisodeOfCare],
     record: T
   ): Boolean =
     episode match {
       case Some(episode) =>
-        reports.exists(sub => sub.episodeOfCare.exists(_ == episode.id) && sub.`type` == Initial)
+        submissionReports.exists(
+          sr =>
+            sr.episodeOfCare
+              // In case EoC-Id is not explicitly defined, look up the pertaining
+              // EpisodeOfCare as that in whose period the submission was made
+              .orElse(record.episodesOfCare.find(_.period contains sr.createdAt.toLocalDate).map(_.id))
+              .exists(_ == episode.id) && sr.`type` == Initial
+        )
 
       case None => 
-        val episodeStart =  record.currentEpisodeOfCare.period.start.atTime(LocalTime.MIN)
-        reports.exists(sub => sub.createdAt.isAfter(episodeStart) && sub.`type` == Initial)
+        val episodeStart = record.currentEpisodeOfCare.period.start.atTime(LocalTime.MIN)
+        submissionReports.exists(sr => sr.createdAt.isAfter(episodeStart) && sr.`type` == Initial)
     }
-
 
 
   override def !(cmd: Command[T])(

--- a/src/main/scala/de/dnpm/dip/service/validation/Validators.scala
+++ b/src/main/scala/de/dnpm/dip/service/validation/Validators.scala
@@ -415,6 +415,9 @@ trait Validators
         validate(record.patient),
         record.getCarePlans.validateEach(
           carePlan => carePlan.boardType must be (defined) otherwise (MissingValue("Board-Typ")) map (_ => carePlan)
+        ),
+        record.episodesOfCare.toList.count(_.period.endOption.isEmpty) must be (lessThanOrEqual (1)) otherwise (
+          Error("Es darf höchstens 1 offene/laufende Behandlungs-Episode vorkommen, d.h. ohne Enddatum") at "Behandlungs-Episoden"
         )
       )
       .errorsOr(record)


### PR DESCRIPTION
The current implementation of https://github.com/dnpm-dip/service-base/blob/549f2dad68e79414ac0e3927e16dd783befa831e/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala#L77 is not robust:

It fails when not _all_ Submission.Reports have `episodeOfCare` defined. This is now corrected by adding fallback resolution of the EpisodeOfCare a given report pertains to.

To complement this, PatientRecord validation was adapted to ensure at most 1 open EpisodeOfCare (i.e. with undefined end date) occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved submission record processing with better fallback logic when episode information is incomplete.
  * Added validation to prevent multiple concurrent treatment episodes, enforcing a maximum of one active episode per patient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->