### PR TITLE
feat: Added event logging of DeletionEvents to be accessible by CDN

### DIFF
--- a/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
@@ -350,7 +350,7 @@ with Logging
 
     val dateTimePeriod = period.copy(
       start = period.start.atTime(LocalTime.MIN),
-      end   = period.end.atTime(LocalTime.MIDNIGHT),
+      end   = period.end.atTime(LocalTime.MAX),
     )
 
     for {

--- a/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
@@ -6,10 +6,15 @@ import java.time.{
   LocalDateTime
 }
 import cats.Monad
-import cats.data.NonEmptyList
+import cats.data.{
+  EitherNel,
+  NonEmptyList
+}
+import cats.syntax.applicative._
 import cats.syntax.either._
 import cats.syntax.functor._
 import cats.syntax.flatMap._
+import cats.syntax.traverse._
 import de.dnpm.dip.util.Logging
 import de.dnpm.dip.model.{
   ClosedPeriod,
@@ -17,6 +22,7 @@ import de.dnpm.dip.model.{
   Id,
   NGSReport,
   PatientRecord,
+  Period,
   Site
 }
 import de.dnpm.dip.service.Distribution
@@ -98,7 +104,7 @@ with Logging
 
   override def !(cmd: Command[T])(
     implicit env: Env
-  ): F[Either[Error,Outcome]] =
+  ): F[EitherNel[Error,Outcome]] =
     cmd match {
 
       case Process(record,metadata) =>
@@ -119,7 +125,7 @@ with Logging
           processingResult <- optTanError match {
 
             // Fail-fast in case of TAN error
-            case Some(tanError) => env.pure(tanError.asLeft)
+            case Some(tanError) => env.pure(tanError.asLeft.toEitherNel)
 
             case None =>
               for {
@@ -170,7 +176,7 @@ with Logging
 
                   case Some(error) => 
                     log.warn(s"${error.msg}, refusing submission")
-                    env.pure(error.asLeft)
+                    env.pure(error.asLeft.toEitherNel)
                   }
 
                } yield result
@@ -191,10 +197,11 @@ with Logging
                     GenericError(_),
                     _ => Updated
                   )
+                  .toEitherNel
                 )
 
             case None =>
-              env.pure(GenericError(s"Invalid TAN $id").asLeft)
+              GenericError(s"Invalid TAN $id").asLeft.toEitherNel.pure
           }
 
         } yield result
@@ -202,13 +209,37 @@ with Logging
 
       case Delete(id) =>
         log.info(s"Deleting MVH data for Patient $id")
-        repo.delete(id)
-          .map(
-            _.bimap(
-              GenericError(_),
-              _ => Deleted
-            )
-          )
+        for {
+          deleteOutcomes <- repo.delete(id)
+
+          result <- deleteOutcomes match {
+            case Right(tans) =>
+              val now = LocalDateTime.now
+
+              //TODO: re-consider whether to discard potential errors from DeletionEvent storage 
+              tans.map(DeletionEvent(id,_,now))
+                .pure
+                .flatTap(_ traverse repo.save)
+                .map(_ => Deleted.asRight)
+
+/* 
+              tans.map(DeletionEvent(id,_,LocalDateTime.now))
+                .traverse(repo.save)
+                .map(
+                  _.map(_.toEitherNel).sequence
+                )
+                .map(
+                  _.bimap(
+                   _.map(GenericError(_)),
+                   _ => Deleted
+                  )
+                )
+ */
+            case Left(errs) => errs.map(GenericError(_)).asLeft.pure
+          }      
+
+        } yield result
+
     }
 
 
@@ -218,7 +249,7 @@ with Logging
       previousSubmissionReport: Option[Submission.Report]
     )(
       implicit env: Monad[F]
-    ): F[Either[Error,Saved.type]] = {
+    ): F[EitherNel[Error,Saved.type]] = {
 
       val submittedAt = LocalDateTime.now
 
@@ -274,6 +305,7 @@ with Logging
           GenericError(_),
           _ => Saved
         )
+        .toEitherNel
       )
 
     }
@@ -354,5 +386,13 @@ with Logging
     repo.patientDataCounts(criteria)
 
   }
+
+
+  override def deletionEvents(
+    period: Period[LocalDateTime],
+  )(
+    implicit env: Env
+  ): F[Seq[DeletionEvent]] =
+    repo.deletionEvents(period)
 
 }

--- a/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
@@ -14,7 +14,6 @@ import cats.syntax.applicative._
 import cats.syntax.either._
 import cats.syntax.functor._
 import cats.syntax.flatMap._
-import cats.syntax.traverse._
 import de.dnpm.dip.util.Logging
 import de.dnpm.dip.model.{
   ClosedPeriod,
@@ -208,36 +207,15 @@ with Logging
 
 
       case Delete(id) =>
-        log.info(s"Deleting MVH data for Patient $id")
+        log.info(s"Deleting MVH Submissions for Patient $id")
         for {
-          deleteOutcomes <- repo.delete(id)
+          outcome <- repo.delete(id)
 
-          result <- deleteOutcomes match {
-            case Right(tans) =>
-              val now = LocalDateTime.now
-
-              //TODO: re-consider whether to discard potential errors from DeletionEvent storage 
-              tans.map(DeletionEvent(id,_,now))
-                .pure
-                .flatTap(_ traverse repo.save)
-                .map(_ => Deleted.asRight)
-
-/* 
-              tans.map(DeletionEvent(id,_,LocalDateTime.now))
-                .traverse(repo.save)
-                .map(
-                  _.map(_.toEitherNel).sequence
-                )
-                .map(
-                  _.bimap(
-                   _.map(GenericError(_)),
-                   _ => Deleted
-                  )
-                )
- */
-            case Left(errs) => errs.map(GenericError(_)).asLeft.pure
-          }      
-
+          result = outcome.bimap(
+            _.map(GenericError(_)),
+            _ => Deleted
+          )
+    
         } yield result
 
     }

--- a/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/BaseMVHService.scala
@@ -328,50 +328,74 @@ with Logging
   ): F[Seq[Submission[T]]] =
     repo ? filter
 
+
   override def submission(id: Id[TransferTAN])(
     implicit env: Env
   ): F[Option[Submission[T]]] =
     repo submission id
 
 
-  // Create BaseReport for the criteria and return it together with the submissions it's based on,
-  // in case the implementing subclass needs to extract additional info from the submissions
-  protected def baseReport(
+  override def report(
     criteria: Report.Criteria
   )(
     implicit env: Env
-  ): F[(BaseReport,Seq[Submission[T]])] = {
+  ): F[Report] = {
 
     log.info(s"Creating MVH Report: $criteria")
 
     val (quarter,period) = criteria match {
       case Report.ForQuarter(n,year)   => Some(n) -> Report.Quarter(n,year)
-      case Report.ForPeriod(start,end) => None -> ClosedPeriod(start,end)
+      case Report.ForPeriod(start,end) => None    -> ClosedPeriod(start,end)
     }
 
+    val dateTimePeriod = period.copy(
+      start = period.start.atTime(LocalTime.MIN),
+      end   = period.end.atTime(LocalTime.MIDNIGHT),
+    )
+
     for {
-      submissions <- repo ? Submission.Filter(
-        period = Some(
-          period.copy(
-            start = period.start.atTime(LocalTime.MIN),
-            end   = period.end.atTime(LocalTime.MIDNIGHT),
-          )
-        )
-      )
+      submissionReports <- repo ? Submission.Report.Filter(period = Some(dateTimePeriod))
 
-      submissionTypes = submissions.map(_.metadata.`type`)
+      submissionTypes = submissionReports.map(_.`type`)
 
-      report = BaseReport(
-        Site.local,
-        LocalDateTime.now,
-        quarter,
-        period,
-        useCase,
-        Distribution.of(submissionTypes),
-        None   // TODO
-      )
+      diagnosticExtents = submissionReports.flatMap(_.diagnosticExtent)
 
-    } yield report -> submissions
+      // Compute the distribution of consent revocations by category (MV, Research)
+      // by accumulating the occurrences of "true" (i.e. revoked) as a List[Consent.Subject.Value].
+      // The distinction of index vs. non-index patient/subject is kept for generality,
+      // but at present, the clinical data only pertains to the index patient
+      consentRevocations =
+        submissionReports.flatMap(_.consentRevocation)
+          .foldLeft(
+            Map.empty[Consent.Category.Value,List[Consent.Subject.Value]]
+          ){
+            (acc,revocationStatus) => revocationStatus.foldLeft(acc){
+              case (acc2,(category,true)) =>
+                acc2.updatedWith(category){
+                  _.map(Consent.Subject.IndexPatient :: _).orElse(Some(List(Consent.Subject.IndexPatient))) 
+                } 
+
+              case (acc2,(_,false)) => acc2
+            }
+          }
+          .map {
+            case (category,subjects) => category -> Distribution.of(subjects)
+          }
+
+      deletions <- repo.deletionEvents(dateTimePeriod)
+
+    } yield Report(
+      Site.local,
+      LocalDateTime.now,
+      quarter,
+      period,
+      useCase,
+      Distribution.of(submissionTypes),
+      Distribution.of(diagnosticExtents),
+      Option.when(consentRevocations.nonEmpty)(consentRevocations),
+      Option.when(deletions.nonEmpty)(deletions.size)
+    )
+
   }
 
 

--- a/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
@@ -317,7 +317,7 @@ with Logging
   private def save(
     event: DeletionEvent
   ): Either[String,DeletionEvent] =
-    Using(new FileWriter(new File(dataDir,s"${DELETION_PREFIX}_TAN_${event.tan}.json"))){
+    Using(new FileWriter(new File(dataDir,s"${DELETION_PREFIX}_TAN_${event.tan.value}.json"))){
       _.write(Json.stringify(Json.toJson(event)))
     }
     .fold(
@@ -341,42 +341,24 @@ with Logging
 
           if (submissionFile.delete){
             cachedPartialSubmissions -= tan
-            reportFile(patId,tan).delete
-            cachedReports -= tan
-            save(DeletionEvent(patId,tan,LocalDateTime.now)).toEitherNel :: events
+
+            val repFile = reportFile(patId,tan)
+
+            if (repFile.delete){
+              cachedReports -= tan
+              save(DeletionEvent(patId,tan,LocalDateTime.now)).toEitherNel :: events
+            } else {
+              log.error(s"Failed to delete $REPORT_PREFIX file $repFile")
+              s"Failed to delete SubmissionReport for TAN $tan".asLeft.toEitherNel :: events
+            }
           } else {
             log.error(s"Failed to delete $SUBMISSION_PREFIX file $submissionFile")
-            s"Failed to delete data for TAN $tan".asLeft.toEitherNel :: events
+            s"Failed to delete Submission for TAN $tan".asLeft.toEitherNel :: events
           }
       }
       
     } yield outcomes.sequence
 
-/*
-  override def delete(id: Id[Patient])(
-    implicit env: Env
-  ): F[EitherNel[String,List[DeletionEvent]]] = 
-    for {
-      subFiles <- submissionFiles(id).pure
-
-      outcomes = subFiles.foldLeft(
-        List.empty[EitherNel[String,DeletionEvent]]
-      ){ 
-        (events,submissionFile) =>
-      
-          val TAN(tan) = submissionFile
-      
-          if (submissionFile.delete){
-            cachedPartialSubmissions -= tan
-            save(DeletionEvent(id,tan,LocalDateTime.now)).toEitherNel :: events
-          } else {
-            log.error(s"Failed to delete $SUBMISSION_PREFIX file $submissionFile")
-            s"Failed to delete data for TAN $tan".asLeft.toEitherNel :: events
-          }
-      }
-      
-    } yield outcomes.sequence
-*/
 
   override def deletionEvents(
     period: Period[LocalDateTime],

--- a/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
@@ -314,42 +314,41 @@ with Logging
     } yield history
 
 
-  override def delete(id: Id[Patient])(
-    implicit env: Env
-  ): F[EitherNel[String,List[Id[TransferTAN]]]] = 
-    for {
-      subFiles <- submissionFiles(id).pure
-
-      outcomes = subFiles.foldLeft(
-        List.empty[EitherNel[String,Id[TransferTAN]]]
-      ){ 
-        (acc,submissionFile) =>
-      
-          val TAN(tan) = submissionFile
-      
-          if (submissionFile.delete){
-            cachedPartialSubmissions -= tan
-            tan.asRight.toEitherNel :: acc 
-          } else {
-            log.error(s"Failed to delete $SUBMISSION_PREFIX file $submissionFile")
-            s"Failed to delete data for TAN $tan".asLeft.toEitherNel :: acc
-          }
-      }
-      
-    } yield outcomes.sequence
-
-
-  def save(event: DeletionEvent)(
-    implicit env: Env
-  ): F[Either[String,Unit]] =
+  private def save(
+    event: DeletionEvent
+  ): Either[String,DeletionEvent] =
     Using(new FileWriter(new File(dataDir,s"${DELETION_PREFIX}_TAN_${event.tan}.json"))){
       _.write(Json.stringify(Json.toJson(event)))
     }
     .fold(
       _ => s"Failed saving DeletionEvent ${Json.toJson(event)}".asLeft,
-      _ => ().asRight
+      _ => event.asRight
     )
-    .pure
+
+
+  override def delete(id: Id[Patient])(
+    implicit env: Env
+  ): F[EitherNel[String,List[DeletionEvent]]] = 
+    for {
+      subFiles <- submissionFiles(id).pure
+
+      outcomes = subFiles.foldLeft(
+        List.empty[EitherNel[String,DeletionEvent]]
+      ){ 
+        (events,submissionFile) =>
+      
+          val TAN(tan) = submissionFile
+      
+          if (submissionFile.delete){
+            cachedPartialSubmissions -= tan
+            save(DeletionEvent(id,tan,LocalDateTime.now)).toEitherNel :: events
+          } else {
+            log.error(s"Failed to delete $SUBMISSION_PREFIX file $submissionFile")
+            s"Failed to delete data for TAN $tan".asLeft.toEitherNel :: events
+          }
+      }
+      
+    } yield outcomes.sequence
 
 
   def deletionEvents(

--- a/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
@@ -22,7 +22,6 @@ import cats.data.{
 }
 import cats.syntax.applicative._
 import cats.syntax.either._
-import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.syntax.traverse._
 import play.api.libs.json.{
@@ -319,32 +318,23 @@ with Logging
     implicit env: Env
   ): F[EitherNel[String,List[Id[TransferTAN]]]] = 
     for {
-      repFiles <- reportFiles(id).pure
       subFiles <- submissionFiles(id).pure
 
-      outcomes =
-        repFiles.zip(subFiles)
-          .foldLeft(
-            List.empty[EitherNel[String,Id[TransferTAN]]]
-          ){ 
-            case (acc,(reportFile,submissionFile)) =>
-          
-              val TAN(tan) = reportFile
-          
-              val submissionDeleted = submissionFile.delete
-              val reportDeleted     = reportFile.delete
-
-              cachedPartialSubmissions -= tan
-              cachedReports -= tan 
-          
-              if (!submissionDeleted) log.error(s"Failed to delete $SUBMISSION_PREFIX file $submissionFile")
-              if (!reportDeleted)     log.error(s"Failed to delete $REPORT_PREFIX file $reportFile")
-          
-              if (submissionDeleted && reportDeleted)
-                tan.asRight.toEitherNel :: acc 
-              else
-                s"Failed to delete data for TAN $tan".asLeft.toEitherNel :: acc
+      outcomes = subFiles.foldLeft(
+        List.empty[EitherNel[String,Id[TransferTAN]]]
+      ){ 
+        (acc,submissionFile) =>
+      
+          val TAN(tan) = submissionFile
+      
+          if (submissionFile.delete){
+            cachedPartialSubmissions -= tan
+            tan.asRight.toEitherNel :: acc 
+          } else {
+            log.error(s"Failed to delete $SUBMISSION_PREFIX file $submissionFile")
+            s"Failed to delete data for TAN $tan".asLeft.toEitherNel :: acc
           }
+      }
       
     } yield outcomes.sequence
 

--- a/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
@@ -7,6 +7,7 @@ import java.io.{
   FileWriter,
   InputStream
 }
+import java.time.LocalDateTime
 import scala.reflect.ClassTag
 import scala.util.chaining._
 import scala.util.Using
@@ -15,11 +16,15 @@ import scala.collection.concurrent.{
   TrieMap
 }
 import cats.Monad
-import cats.data.NonEmptyList
-import cats.syntax.functor._
-import cats.syntax.flatMap._
+import cats.data.{
+  EitherNel,
+  NonEmptyList
+}
 import cats.syntax.applicative._
 import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
 import play.api.libs.json.{
   Json,
   Reads,
@@ -32,11 +37,13 @@ import de.dnpm.dip.model.{
   Id,
   Patient,
   PatientRecord,
+  Period
 }
 import de.dnpm.dip.service.controlling.{
   Controlling,
   PatientDataCounts
 }
+import MVHService.DeletionEvent
 
 
 // Extractor for TANs according to file naming pattern below
@@ -85,6 +92,9 @@ with Logging
   private val REPORT_PREFIX = "SubmissionReport"
 
   private val SUBMISSION_PREFIX = s"MVH_${classTag.runtimeClass.getSimpleName}"
+
+  private val DELETION_PREFIX = "DeletionEvent"
+
 
   private def reportFile(id: Id[Patient], tan: Id[TransferTAN]): File =
     new File(dataDir,s"${REPORT_PREFIX}_Patient_${id.value}_TAN_${tan.value}.json")
@@ -149,7 +159,6 @@ with Logging
       .map(readAsJson[PartialSubmission])
       .map(sub => sub.metadata.transferTAN -> sub)
     )
-
 
 
   override def alreadyUsed(id: Id[TransferTAN])(
@@ -308,38 +317,63 @@ with Logging
 
   override def delete(id: Id[Patient])(
     implicit env: Env
-  ): F[Either[String,Unit]] =
+  ): F[EitherNel[String,List[Id[TransferTAN]]]] = 
     for {
       repFiles <- reportFiles(id).pure
       subFiles <- submissionFiles(id).pure
 
-      submissionDeletionErrors =
-        subFiles.foldLeft(List.empty[String]){
-          (acc,file) => 
-            if (file.delete){
-              val TAN(tan) = file
+      outcomes =
+        repFiles.zip(subFiles)
+          .foldLeft(
+            List.empty[EitherNel[String,Id[TransferTAN]]]
+          ){ 
+            case (acc,(reportFile,submissionFile)) =>
+          
+              val TAN(tan) = reportFile
+          
+              val submissionDeleted = submissionFile.delete
+              val reportDeleted     = reportFile.delete
+
               cachedPartialSubmissions -= tan
-              acc
-            }
-            else s"Failed to delete $SUBMISSION_PREFIX file $file".tap(log.error) :: acc
-        }
-
-      deletionErrors =
-        repFiles.foldLeft(submissionDeletionErrors){
-          (acc,file) =>
-            if (file.delete){
-              val TAN(tan) = file
               cachedReports -= tan 
-              acc
-            }
-            else s"Failed to delete $REPORT_PREFIX file $file".tap(log.error) :: acc
-        }
+          
+              if (!submissionDeleted) log.error(s"Failed to delete $SUBMISSION_PREFIX file $submissionFile")
+              if (!reportDeleted)     log.error(s"Failed to delete $REPORT_PREFIX file $reportFile")
+          
+              if (submissionDeleted && reportDeleted)
+                tan.asRight.toEitherNel :: acc 
+              else
+                s"Failed to delete data for TAN $tan".asLeft.toEitherNel :: acc
+          }
+      
+    } yield outcomes.sequence
 
-      result =
-        if (deletionErrors.isEmpty) ().asRight
-        else deletionErrors.mkString("; ").asLeft
 
-    } yield result
+  def save(event: DeletionEvent)(
+    implicit env: Env
+  ): F[Either[String,Unit]] =
+    Using(new FileWriter(new File(dataDir,s"${DELETION_PREFIX}_TAN_${event.tan}.json"))){
+      _.write(Json.stringify(Json.toJson(event)))
+    }
+    .fold(
+      _ => s"Failed saving DeletionEvent ${Json.toJson(event)}".asLeft,
+      _ => ().asRight
+    )
+    .pure
+
+
+  def deletionEvents(
+    period: Period[LocalDateTime],
+  )(
+    implicit env: Env
+  ): F[LazyList[DeletionEvent]] =
+    dataDir.listFiles(
+      (_,name) => (name startsWith DELETION_PREFIX) && (name endsWith ".json")
+    )
+    .to(LazyList)
+    .map(new FileInputStream(_))
+    .map(readAsJson[DeletionEvent])
+    .filter(period)
+    .pure
 
 }
-

--- a/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
@@ -351,7 +351,7 @@ with Logging
     } yield outcomes.sequence
 
 
-  def deletionEvents(
+  override def deletionEvents(
     period: Period[LocalDateTime],
   )(
     implicit env: Env

--- a/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/FSBackedRepository.scala
@@ -326,6 +326,33 @@ with Logging
     )
 
 
+  override def delete(patId: Id[Patient])(
+    implicit env: Env
+  ): F[EitherNel[String,List[DeletionEvent]]] = 
+    for {
+      subFiles <- submissionFiles(patId).pure
+
+      outcomes = subFiles.foldLeft(
+        List.empty[EitherNel[String,DeletionEvent]]
+      ){ 
+        (events,submissionFile) =>
+      
+          val TAN(tan) = submissionFile
+
+          if (submissionFile.delete){
+            cachedPartialSubmissions -= tan
+            reportFile(patId,tan).delete
+            cachedReports -= tan
+            save(DeletionEvent(patId,tan,LocalDateTime.now)).toEitherNel :: events
+          } else {
+            log.error(s"Failed to delete $SUBMISSION_PREFIX file $submissionFile")
+            s"Failed to delete data for TAN $tan".asLeft.toEitherNel :: events
+          }
+      }
+      
+    } yield outcomes.sequence
+
+/*
   override def delete(id: Id[Patient])(
     implicit env: Env
   ): F[EitherNel[String,List[DeletionEvent]]] = 
@@ -349,7 +376,7 @@ with Logging
       }
       
     } yield outcomes.sequence
-
+*/
 
   override def deletionEvents(
     period: Period[LocalDateTime],

--- a/src/main/scala/de/dnpm/dip/service/mvh/MVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/MVHService.scala
@@ -1,17 +1,26 @@
 package de.dnpm.dip.service.mvh
 
 
+import java.time.LocalDateTime
+import cats.data.EitherNel
 import de.dnpm.dip.service.controlling.Controlling
 import de.dnpm.dip.model.{
   Id,
   Patient,
   PatientRecord,
+  Period
 }
+import play.api.libs.json.{
+  Json,
+  OFormat
+}
+
 
 trait MVHService[F[_],Env,T <: PatientRecord] extends Controlling.Ops[F,Env]
 {
   import MVHService.{
     Command,
+    DeletionEvent,
     Error,
     Outcome
   }
@@ -27,7 +36,7 @@ trait MVHService[F[_],Env,T <: PatientRecord] extends Controlling.Ops[F,Env]
    */
   def !(cmd: Command[T])(
     implicit env: Env
-  ): F[Either[Error,Outcome]]
+  ): F[EitherNel[Error,Outcome]]
 
 
   def ?(filter: Submission.Report.Filter)(
@@ -60,6 +69,13 @@ trait MVHService[F[_],Env,T <: PatientRecord] extends Controlling.Ops[F,Env]
     implicit env: Env
   ): F[ReportType]
 
+
+  def deletionEvents(
+    period: Period[LocalDateTime],
+  )(
+    implicit env: Env
+  ): F[Seq[DeletionEvent]]
+
 }
 
 
@@ -76,14 +92,28 @@ object MVHService
   final case class ConfirmSubmitted(id: Id[TransferTAN]) extends Command[Nothing]
   final case class Delete(id: Id[Patient]) extends Command[Nothing]
 
+
   sealed trait Outcome
   final case object Saved extends Outcome
   final case object Updated extends Outcome
   final case object Deleted extends Outcome
 
+
   sealed trait Error
   final case class InvalidTAN(msg: String) extends Error
   final case class InvalidSubmissionType(msg: String) extends Error
   final case class GenericError(msg: String) extends Error
+
+
+
+  final case class DeletionEvent
+  (
+    patient: Id[Patient],
+    tan: Id[TransferTAN],
+    dateTime: LocalDateTime
+  )
+
+  implicit val formatDeletionEvent: OFormat[DeletionEvent] =
+    Json.format[DeletionEvent]
 
 }

--- a/src/main/scala/de/dnpm/dip/service/mvh/MVHService.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/MVHService.scala
@@ -25,8 +25,6 @@ trait MVHService[F[_],Env,T <: PatientRecord] extends Controlling.Ops[F,Env]
     Outcome
   }
 
-  type ReportType <: Report
-
   val useCase: UseCase.Value
 
   /**
@@ -67,7 +65,7 @@ trait MVHService[F[_],Env,T <: PatientRecord] extends Controlling.Ops[F,Env]
     criteria: Report.Criteria
   )(
     implicit env: Env
-  ): F[ReportType]
+  ): F[Report]
 
 
   def deletionEvents(

--- a/src/main/scala/de/dnpm/dip/service/mvh/Report.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/Report.scala
@@ -20,7 +20,21 @@ import play.api.libs.json.{
 }
 
 
-object Report
+final case class Report
+(
+  site: Coding[Site],
+  createdAt: LocalDateTime,
+  quarter: Option[Report.Quarter.Value],
+  period: ClosedPeriod[LocalDate],
+  useCase: UseCase.Value,
+  submissionTypes: Distribution[Submission.Type.Value],
+  diagnosticExtents: Distribution[Submission.DiagnosticExtent.Value],
+  consentRevocations: Option[Map[Consent.Category.Value,Distribution[Consent.Subject.Value]]],
+  deletions: Option[Int]
+)
+
+
+object Report extends  JsonEnumKeyHelpers
 {
 
   type Quarter = ClosedPeriod[LocalDate]
@@ -59,36 +73,8 @@ object Report
   final case class ForQuarter(quarter: Quarter.Value, year: Option[Year]) extends Criteria
   final case class ForPeriod(start: LocalDate, end: LocalDate) extends Criteria
 
-}
 
+  implicit val format: OFormat[Report] =
+    Json.format[Report]
 
-trait Report
-{
-  val site: Coding[Site]
-  val createdAt: LocalDateTime
-  val quarter: Option[Report.Quarter.Value]
-  val period: ClosedPeriod[LocalDate]
-  val useCase: UseCase.Value
-  val submissionTypes: Distribution[Submission.Type.Value]
-  val consentRevocations: Option[Map[Consent.Category.Value,Distribution[Consent.Subject.Value]]]
-}
-
-
-final case class BaseReport
-(
-  site: Coding[Site],
-  createdAt: LocalDateTime,
-  quarter: Option[Report.Quarter.Value],
-  period: ClosedPeriod[LocalDate],
-  useCase: UseCase.Value,
-  submissionTypes: Distribution[Submission.Type.Value],
-  consentRevocations: Option[Map[Consent.Category.Value,Distribution[Consent.Subject.Value]]]
-)
-extends Report
-
-
-object BaseReport extends JsonEnumKeyHelpers
-{
-  implicit val format: OFormat[BaseReport] =
-    Json.format[BaseReport]
 }

--- a/src/main/scala/de/dnpm/dip/service/mvh/Repository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/Repository.scala
@@ -1,12 +1,16 @@
 package de.dnpm.dip.service.mvh
 
 
+import java.time.LocalDateTime
+import cats.data.EitherNel
 import de.dnpm.dip.model.{
   History,
   Id,
   Patient,
   PatientRecord,
+  Period
 }
+import MVHService.DeletionEvent
 import de.dnpm.dip.service.controlling.Controlling
 
 
@@ -20,11 +24,16 @@ trait Repository[F[_],Env,T <: PatientRecord] extends Controlling.Ops[F,Env]
       filter.`type`.map(_ contains report.`type`).getOrElse(true) &&
       filter.patient.map(_ contains report.patient).getOrElse(true)
 
+
   protected implicit def submissionPredicate(filter: Submission.Filter): Submission[T] => Boolean =
     submission =>
       filter.period.map(_ contains submission.submittedAt).getOrElse(true) &&
       filter.`type`.map(_ contains submission.metadata.`type`).getOrElse(true) 
 
+
+  protected implicit def deletionEventPredicate(period: Period[LocalDateTime]): DeletionEvent => Boolean =
+    event => period contains event.dateTime
+  
   
   def alreadyUsed(id: Id[TransferTAN])(
     implicit env: Env
@@ -79,6 +88,18 @@ trait Repository[F[_],Env,T <: PatientRecord] extends Controlling.Ops[F,Env]
 
   def delete(id: Id[Patient])(
     implicit env: Env
+  ): F[EitherNel[String,Seq[Id[TransferTAN]]]]
+
+
+  def save(event: DeletionEvent)(
+    implicit env: Env
   ): F[Either[String,Unit]]
+
+
+  def deletionEvents(
+    period: Period[LocalDateTime],
+  )(
+    implicit env: Env
+  ): F[Seq[DeletionEvent]]
 
 }

--- a/src/main/scala/de/dnpm/dip/service/mvh/Repository.scala
+++ b/src/main/scala/de/dnpm/dip/service/mvh/Repository.scala
@@ -85,15 +85,10 @@ trait Repository[F[_],Env,T <: PatientRecord] extends Controlling.Ops[F,Env]
     implicit env: Env
   ): F[Option[History[Submission.Report]]]
 
-
+  
   def delete(id: Id[Patient])(
     implicit env: Env
-  ): F[EitherNel[String,Seq[Id[TransferTAN]]]]
-
-
-  def save(event: DeletionEvent)(
-    implicit env: Env
-  ): F[Either[String,Unit]]
+  ): F[EitherNel[String,Seq[DeletionEvent]]]
 
 
   def deletionEvents(

--- a/src/test/scala/de/dnpm/dip/service/OrchestratorTests.scala
+++ b/src/test/scala/de/dnpm/dip/service/OrchestratorTests.scala
@@ -138,9 +138,9 @@ class OrchestratorTests extends AsyncFlatSpec
     
       _ = outcome.value mustBe a [Deleted]
 
-      submissionReport <- mvhService submissionReport initialUpload.metadata.get.transferTAN
+      submission <- mvhService submission initialUpload.metadata.get.transferTAN
 
-      _ = submissionReport must not be defined
+      _ = submission must not be defined
     
       snapshot <- queryService ! retrievalRequest
 

--- a/src/test/scala/de/dnpm/dip/service/OrchestratorTests.scala
+++ b/src/test/scala/de/dnpm/dip/service/OrchestratorTests.scala
@@ -139,8 +139,10 @@ class OrchestratorTests extends AsyncFlatSpec
       _ = outcome.value mustBe a [Deleted]
 
       submission <- mvhService submission initialUpload.metadata.get.transferTAN
+      submissionReport <- mvhService submissionReport initialUpload.metadata.get.transferTAN
 
       _ = submission must not be defined
+      _ = submissionReport must not be defined
     
       snapshot <- queryService ! retrievalRequest
 

--- a/src/test/scala/de/dnpm/dip/service/mvh/FSBackedRepositoryTests.scala
+++ b/src/test/scala/de/dnpm/dip/service/mvh/FSBackedRepositoryTests.scala
@@ -1,12 +1,14 @@
 package de.dnpm.dip.service.mvh
 
 
+import java.time.LocalDateTime
 import java.nio.file.Files.createTempDirectory
 import scala.concurrent.Future
 import scala.util.Random
 import cats.syntax.traverse._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.must.Matchers._
+import de.dnpm.dip.model.Period
 import de.dnpm.dip.service.DummyPatientRecord
 import de.dnpm.dip.service.Gens._
 import de.ekut.tbi.generators.Gen
@@ -51,8 +53,9 @@ class FSBackedRepositoryTests extends AsyncFlatSpec
 
     val n = 42
 
-    val submissions =
-      List.fill(n)(metadata.next).map(Gen.of[DummyPatientRecord].next -> _)
+    val submissions = List.fill(n)(metadata.next).map(Gen.of[DummyPatientRecord].next -> _)
+
+    val start = LocalDateTime.now
 
     for { 
 
@@ -60,7 +63,7 @@ class FSBackedRepositoryTests extends AsyncFlatSpec
 
       _ = all (saveOutcomes) must matchPattern { case Right(Saved) => }
 
-      // For each Submission, a Submission and Submission.Report file must have be created, hence the factor of 2
+      // For each Submission, a Submission and Submission.Report file must have been created, hence the factor of 2
       _ = dataDir.listFiles.size mustBe 2*n
 
 
@@ -84,7 +87,11 @@ class FSBackedRepositoryTests extends AsyncFlatSpec
       _ = all (submissionsAfterDeletion) must be (empty)
       _ = all (submissionReportsAfterDeletion) must be (empty)
 
-      _ = dataDir.listFiles mustBe empty
+      _ = dataDir.listFiles((_,name) => !(name startsWith "Deletion")) mustBe empty
+
+      deletionEvents <- service.deletionEvents(Period(start,LocalDateTime.now))
+
+      _ = deletionEvents.size mustBe n
 
     } yield succeed // If this point is reached, test succeeded
 

--- a/src/test/scala/de/dnpm/dip/service/mvh/FSBackedRepositoryTests.scala
+++ b/src/test/scala/de/dnpm/dip/service/mvh/FSBackedRepositoryTests.scala
@@ -66,7 +66,6 @@ class FSBackedRepositoryTests extends AsyncFlatSpec
       // For each Submission, a Submission and Submission.Report file must have been created, hence the factor of 2
       _ = dataDir.listFiles.size mustBe 2*n
 
-
       loadedSubmissions <- service ? Submission.Filter()
 
       _ = loadedSubmissions.size mustBe n
@@ -81,13 +80,13 @@ class FSBackedRepositoryTests extends AsyncFlatSpec
 
       _ = all (deletionOutcomes) must matchPattern { case Right(Deleted) => }
 
+
       submissionsAfterDeletion <- submissions.map(_._2.transferTAN).traverse(service submission _)
-      submissionReportsAfterDeletion <- submissions.map(_._2.transferTAN).traverse(service submissionReport _)
 
       _ = all (submissionsAfterDeletion) must be (empty)
-      _ = all (submissionReportsAfterDeletion) must be (empty)
 
-      _ = dataDir.listFiles((_,name) => !(name startsWith "Deletion")) mustBe empty
+      _ = dataDir.listFiles((_,name) => name contains "MVH_DummyPatientRecord") mustBe empty
+
 
       deletionEvents <- service.deletionEvents(Period(start,LocalDateTime.now))
 

--- a/src/test/scala/de/dnpm/dip/service/mvh/FSBackedRepositoryTests.scala
+++ b/src/test/scala/de/dnpm/dip/service/mvh/FSBackedRepositoryTests.scala
@@ -66,9 +66,9 @@ class FSBackedRepositoryTests extends AsyncFlatSpec
       // For each Submission, a Submission and Submission.Report file must have been created, hence the factor of 2
       _ = dataDir.listFiles.size mustBe 2*n
 
-      loadedSubmissions <- service ? Submission.Filter()
+      queriedSubmissions <- service ? Submission.Filter()
 
-      _ = loadedSubmissions.size mustBe n
+      _ = queriedSubmissions.size mustBe n
 
 
       submissionsByTAN <- submissions.map(_._2.transferTAN).traverse(service.submission(_))
@@ -82,10 +82,13 @@ class FSBackedRepositoryTests extends AsyncFlatSpec
 
 
       submissionsAfterDeletion <- submissions.map(_._2.transferTAN).traverse(service submission _)
+      reportsAfterDeletion     <- submissions.map(_._2.transferTAN).traverse(service submissionReport _)
 
       _ = all (submissionsAfterDeletion) must be (empty)
+      _ = all (reportsAfterDeletion) must be (empty)
 
       _ = dataDir.listFiles((_,name) => name contains "MVH_DummyPatientRecord") mustBe empty
+      _ = dataDir.listFiles((_,name) => name contains "SubmissionReport") mustBe empty
 
 
       deletionEvents <- service.deletionEvents(Period(start,LocalDateTime.now))

--- a/src/test/scala/de/dnpm/dip/service/mvh/FakeMVHService.scala
+++ b/src/test/scala/de/dnpm/dip/service/mvh/FakeMVHService.scala
@@ -14,18 +14,9 @@ extends BaseMVHService[F,T](
   repository
 ){
 
-  type ReportType = BaseReport
-
 
   override def diagnosticExtent(record: T) = None
 
   override def sequenceTypes(record: T) = None
-
-  override def report(
-    criteria: Report.Criteria
-  )(
-    implicit env: Monad[F]
-  ): F[ReportType] =
-    env.map(baseReport(criteria))(_._1)
 
 }

--- a/src/test/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
+++ b/src/test/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
@@ -1,12 +1,16 @@
 package de.dnpm.dip.service.mvh
 
 
+import java.time.LocalDateTime
 import scala.collection.concurrent.{
   Map,
   TrieMap
 }
 import cats.Monad
-import cats.data.NonEmptyList
+import cats.data.{
+  EitherNel,
+  NonEmptyList
+}
 import cats.syntax.applicative._
 import cats.syntax.either._
 import de.dnpm.dip.model.{
@@ -14,11 +18,14 @@ import de.dnpm.dip.model.{
   Id,
   Patient,
   PatientRecord,
+  Period
 }
+
 import de.dnpm.dip.service.controlling.{
   Controlling,
   PatientDataCounts
 }
+import MVHService.DeletionEvent
 
 
 class InMemRepository[F[_],T <: PatientRecord] extends Repository[F,Monad[F],T]
@@ -31,6 +38,9 @@ class InMemRepository[F[_],T <: PatientRecord] extends Repository[F,Monad[F],T]
     TrieMap.empty
 
   private val submissions: Map[Id[Patient],Map[Id[TransferTAN],Submission[T]]] =
+    TrieMap.empty
+
+  private val deletions: Map[Id[TransferTAN],DeletionEvent] =
     TrieMap.empty
 
 
@@ -165,11 +175,33 @@ class InMemRepository[F[_],T <: PatientRecord] extends Repository[F,Monad[F],T]
 
   override def delete(id: Id[Patient])(
     implicit env: Env
-  ): F[Either[String,Unit]] = {
-    reports -= id
+  ): F[EitherNel[String,Seq[Id[TransferTAN]]]] = {
+
     submissions -= id
 
-    ().asRight[String].pure
+    val tans = reports.remove(id).map(_.keys.toSeq)
+
+    tans.toRight(s"Invalid Patient ID $id").toEitherNel.pure
   }
 
+
+  override def save(event: DeletionEvent)(
+    implicit env: Env
+  ): F[Either[String,Unit]] = {
+    deletions += event.tan -> event    
+    ().asRight.pure 
+  }
+
+
+  override def deletionEvents(
+    period: Period[LocalDateTime],
+  )(
+    implicit env: Env
+  ): F[Seq[DeletionEvent]] =
+    deletions.values
+      .filter(period)
+      .toSeq
+      .pure
+
+  
 }

--- a/src/test/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
+++ b/src/test/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
@@ -173,25 +173,20 @@ class InMemRepository[F[_],T <: PatientRecord] extends Repository[F,Monad[F],T]
     }
 
 
+  // Remove all Submissions and return recorded DeletionEvents 
   override def delete(id: Id[Patient])(
     implicit env: Env
-  ): F[EitherNel[String,Seq[Id[TransferTAN]]]] = {
-
-    submissions -= id
-
-    val tans = reports.remove(id).map(_.keys.toSeq)
-
-    tans.getOrElse(Nil).asRight.toEitherNel.pure
-  }
-
-
-  override def save(event: DeletionEvent)(
-    implicit env: Env
-  ): F[Either[String,Unit]] = {
-    deletions += event.tan -> event    
-    ().asRight.pure 
-  }
-
+  ): F[EitherNel[String,Seq[DeletionEvent]]] =
+    submissions
+      .remove(id)
+      .map(_.keys.toSeq)
+      .getOrElse(Nil)
+      .map(DeletionEvent(id,_,LocalDateTime.now))
+      .tapEach(event => deletions += event.tan -> event)
+      .asRight
+      .toEitherNel
+      .pure
+  
 
   override def deletionEvents(
     period: Period[LocalDateTime],

--- a/src/test/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
+++ b/src/test/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
@@ -181,7 +181,7 @@ class InMemRepository[F[_],T <: PatientRecord] extends Repository[F,Monad[F],T]
 
     val tans = reports.remove(id).map(_.keys.toSeq)
 
-    tans.toRight(s"Invalid Patient ID $id").toEitherNel.pure
+    tans.getOrElse(Nil).asRight.toEitherNel.pure
   }
 
 

--- a/src/test/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
+++ b/src/test/scala/de/dnpm/dip/service/mvh/InMemRepository.scala
@@ -172,8 +172,8 @@ class InMemRepository[F[_],T <: PatientRecord] extends Repository[F,Monad[F],T]
       )
     }
 
-
-  // Remove all Submissions and return recorded DeletionEvents 
+/*
+  // Remove all Submissions for the Patient and return recorded DeletionEvents 
   override def delete(id: Id[Patient])(
     implicit env: Env
   ): F[EitherNel[String,Seq[DeletionEvent]]] =
@@ -185,8 +185,26 @@ class InMemRepository[F[_],T <: PatientRecord] extends Repository[F,Monad[F],T]
       .tapEach(event => deletions += event.tan -> event)
       .asRight
       .toEitherNel
+      .pure  
+*/
+
+  // Remove all SubmissionReports and Submissions for the Patient, 
+  // and return recorded DeletionEvents 
+  override def delete(id: Id[Patient])(
+    implicit env: Env
+  ): F[EitherNel[String,Seq[DeletionEvent]]] = {
+    reports -= id
+
+    submissions
+      .remove(id)
+      .map(_.keys.toSeq)
+      .getOrElse(Nil)
+      .map(DeletionEvent(id,_,LocalDateTime.now))
+      .tapEach(event => deletions += event.tan -> event)
+      .asRight
+      .toEitherNel
       .pure
-  
+  }
 
   override def deletionEvents(
     period: Period[LocalDateTime],
@@ -198,5 +216,4 @@ class InMemRepository[F[_],T <: PatientRecord] extends Repository[F,Monad[F],T]
       .toSeq
       .pure
 
-  
 }

--- a/src/test/scala/de/dnpm/dip/service/mvh/MVHServiceTests.scala
+++ b/src/test/scala/de/dnpm/dip/service/mvh/MVHServiceTests.scala
@@ -3,6 +3,7 @@ package de.dnpm.dip.service.mvh
 
 import scala.concurrent.Future
 import scala.util.Random
+import cats.data.NonEmptyList
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.EitherValues._
 import org.scalatest.Inspectors._
@@ -66,7 +67,7 @@ class MVHServiceTests extends AsyncFlatSpec
     for { 
       outcomes <- nonInitialMetadata.next.traverse(service ! Process(record,_))
 
-    } yield all (outcomes) must matchPattern { case Left(_: InvalidSubmissionType) => }
+    } yield all (outcomes) must matchPattern { case Left(NonEmptyList(_: InvalidSubmissionType,Nil)) => }
 
   }
 
@@ -82,7 +83,7 @@ class MVHServiceTests extends AsyncFlatSpec
 
       outcome2 <- service ! Process(record,initialMetadata.next)
 
-    } yield outcome2 must matchPattern { case Left(_: InvalidSubmissionType) => }
+    } yield outcome2 must matchPattern { case Left(NonEmptyList(_: InvalidSubmissionType,Nil)) => }
 
   }
 
@@ -123,7 +124,7 @@ class MVHServiceTests extends AsyncFlatSpec
           .map(_.withEpisodeOfCare(newEpisode))
           .traverse(service ! Process(recordWithNewEpisode,_))
 
-    } yield all (outcomes2) must matchPattern { case Left(_: InvalidSubmissionType) => }
+    } yield all (outcomes2) must matchPattern { case Left(NonEmptyList(_: InvalidSubmissionType,Nil)) => }
 
   }
 


### PR DESCRIPTION
Added functionality to record deletions of MVH data as DeletionEvent, in order to be accessible/trackable by CDN for quarter reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deletion-event tracking, persistence, and time-window querying.
  * Service reports now include a deletion count derived from stored deletion events.
* **Bug Fixes**
  * Standardized command/validation error handling to accumulate multiple errors.
  * Improved delete/confirm flows to return richer multi-error results.
* **Tests**
  * Updated repository and service tests to validate deletion-event persistence, filtering, and new multi-error shapes.
* **Chores**
  * Refreshed report model/serialization to support the new deletions field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->